### PR TITLE
fix: Add style for the 'O'; change to 'O' after plays 'X'

### DIFF
--- a/src/components/Square/Square.css
+++ b/src/components/Square/Square.css
@@ -24,4 +24,8 @@ button:hover {
 .O {
     color: #CC0000;
     background-color: #0582CA;
+    font-family: "Fredoka", sans-serif;
+    font-weight: 700;
+    font-style: normal;
+    font-size: 3rem;
 }

--- a/src/components/Square/Square.jsx
+++ b/src/components/Square/Square.jsx
@@ -11,7 +11,7 @@ function Square({index}) {
             const newBoard = [...board];
             newBoard[index] = value;
             setBoard(newBoard);
-            setValue(value === "X" ? "X" : "O");
+            setValue(value === "X" ? "O" : "X");
         }
     };
 


### PR DESCRIPTION
`setValue(value === "X" ? "O" : "X");`

**It was originally** `setValue(value === "X" ? "X" : "O");` 
**This would only display 'X' whenever the squares are clicked on.**